### PR TITLE
Добавить поиск по регулярным выражениям с подсказкой

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,8 @@ export interface LogFilter {
 
 export type SortOrder = 'asc' | 'desc';
 
+export type SearchMode = 'text' | 'regex';
+
 // Svelte 5 runes types
 export type State<T> = T;
 export type Derived<T> = T;


### PR DESCRIPTION
Add regular expression search functionality with a usage hint and error handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-9e28b779-dc2c-4373-87b0-c370a7c75d15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9e28b779-dc2c-4373-87b0-c370a7c75d15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a regex search mode with UI toggle, error handling and hint, updates filtering logic to support RegExp, and adds corresponding types and styles.
> 
> - **Search**:
>   - Add `regex` search mode alongside text; implement RegExp-based filtering with error handling in `src/App.svelte` (`searchMode`, `searchError`, `handleSearchModeChange`).
>   - Preserve text search behavior when not in regex mode.
> - **UI/Controls (`src/components/LogControls.svelte`)**:
>   - Add radio toggle for `searchMode` (`text`/`regex`), dynamic placeholder, and input styling for regex mode.
>   - Display validation errors (`searchError`) and a collapsible regex usage hint.
>   - Wire new handler `onSearchModeChange` and propagate `searchMode`/`searchError` props.
> - **Types (`src/types.ts`)**:
>   - Add `SearchMode` type (`'text' | 'regex'`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b40bcab17af08c7e9a8bfaa8a80182f7dea33fdb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->